### PR TITLE
Don't let the mapping be nil when reading an empty file

### DIFF
--- a/pkg/partition_info/partition_info.go
+++ b/pkg/partition_info/partition_info.go
@@ -71,6 +71,10 @@ func (pi PartitionInfo) UpdateMapping(partitionData string) error {
 	return pi.save()
 }
 
+func (pi PartitionInfo) IsMappingNil() bool {
+	return pi.mapping == nil
+}
+
 func (pi PartitionInfo) save() error {
 	data, err := yaml.Marshal(&pi.mapping)
 	if err != nil {
@@ -106,6 +110,9 @@ func ParsePartitionInfoFile(file string) (map[string]string, error) {
 	err = yaml.Unmarshal(yamlFile, &result)
 	if err != nil {
 		return result, errors.Wrap(err, "unmarshalling partition info file")
+	}
+	if result == nil {
+		result = map[string]string{}
 	}
 
 	return result, nil

--- a/pkg/partition_info/partition_info_test.go
+++ b/pkg/partition_info/partition_info_test.go
@@ -38,13 +38,15 @@ var _ = Describe("Partition Info file parsing", func() {
 					fmt.Sprintf("partition-info-%d.yaml", time.Now().UnixNano()))
 			})
 
-			It("creates the file and returns 'false' and an (empty) mapping", func() {
+			It("creates the file and returns 'false' and a non nil mapping", func() {
 				result, existed, err := pi.NewPartitionInfoFromFile(fileName)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).ToNot(BeNil())
 				Expect(existed).To(BeFalse())
 				_, err = os.Stat(fileName)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(result).ToNot(BeNil())
+				Expect(result.IsMappingNil()).To(BeFalse())
 			})
 		})
 	})


### PR DESCRIPTION
e.g. when we first create it

because it throws this error:

```
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/kairos-io/kcrypt/pkg/partition_info.PartitionInfo.UpdateMapping({{0xa60325?, 0x18?}, 0x0?}, {0xc000302000?, 0x1?})
	/go/pkg/mod/github.com/kairos-io/kcrypt@v0.4.2/pkg/partition_info/partition_info.go:69 +0x99

```

Signed-off-by: Dimitris Karakasilis <dimitris@karakasilis.me>