### PR TITLE
:seedling: Remove challenger traces from here

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,6 @@ var MappingsFile = "/oem/91-kcrypt-mappings.yaml"
 
 type Config struct {
 	Kcrypt struct {
-		Server            string            `yaml:"challenger_server,omitempty"`
 		UUIDLabelMappings map[string]string `yaml:"uuid_label_mappings,omitempty"`
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -27,7 +27,6 @@ var _ = Describe("Config", func() {
 			It("returns empty Config", func() {
 				c, err := configpkg.GetConfiguration([]string{tmpDir})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(c.Kcrypt.Server).To(BeEmpty())
 				Expect(c.Kcrypt.UUIDLabelMappings).To(BeEmpty())
 			})
 		})
@@ -40,8 +39,6 @@ var _ = Describe("Config", func() {
 				Expect(err).ToNot(HaveOccurred())
 				data := []byte(`#cloud-config
 kcrypt:
-  challenger_server: http://test.org:8082
-
   uuid_label_mappings:
     COS_PERSISTENT: some_uuid_here
 `)
@@ -52,7 +49,6 @@ kcrypt:
 			It("returns the Config", func() {
 				c, err := configpkg.GetConfiguration([]string{tmpDir})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(c.Kcrypt.Server).To(Equal("http://test.org:8082"))
 				Expect(c.Kcrypt.UUIDLabelMappings["COS_PERSISTENT"]).To(Equal("some_uuid_here"))
 			})
 		})
@@ -84,7 +80,6 @@ kcrypt:
 			It("returns the merged Config", func() {
 				c, err := configpkg.GetConfiguration([]string{tmpDir})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(c.Kcrypt.Server).To(Equal("http://test.org:8082"))
 				Expect(c.Kcrypt.UUIDLabelMappings["COS_PERSISTENT"]).To(Equal("some_uuid_here"))
 			})
 		})


### PR DESCRIPTION
The challenger has no business logic in here, and kcrypt should just read what it needs. This goes in parallel with https://github.com/kairos-io/kcrypt-challenger/pull/10 Not blocking each other.

Signed-off-by: mudler <mudler@c3os.io>