### PR TITLE
Skip kcrypt on non-immmutable systems

### DIFF
--- a/dracut/29kcrypt/generator.sh
+++ b/dracut/29kcrypt/generator.sh
@@ -14,7 +14,7 @@ oem_label=$(getarg rd.cos.oemlabel=)
 if getargbool 0 rd.cos.disable; then
     exit 0
 fi
-// Netboot is set on...well, netboot obiously
+## Netboot is set on...well, netboot obiously
 if getargbool 0 netboot; then
     exit 0
 fi

--- a/dracut/29kcrypt/generator.sh
+++ b/dracut/29kcrypt/generator.sh
@@ -9,8 +9,8 @@ GENERATOR_DIR="$2"
 
 oem_label=$(getarg rd.cos.oemlabel=)
 
-// Several things indicate booting from a different media so we should not do anything
-// rd.cos.disable is set on LIVECD and disables mounting of any type
+## Several things indicate booting from a different media so we should not do anything
+## rd.cos.disable is set on LIVECD and disables mounting of any type
 if getargbool 0 rd.cos.disable; then
     exit 0
 fi

--- a/dracut/29kcrypt/generator.sh
+++ b/dracut/29kcrypt/generator.sh
@@ -9,6 +9,17 @@ GENERATOR_DIR="$2"
 
 oem_label=$(getarg rd.cos.oemlabel=)
 
+// Several things indicate booting from a different media so we should not do anything
+// rd.cos.disable is set on LIVECD and disables mounting of any type
+if getargbool 0 rd.cos.disable; then
+    exit 0
+fi
+// Netboot is set on...well, netboot obiously
+if getargbool 0 netboot; then
+    exit 0
+fi
+
+
 # See https://github.com/kairos-io/packages/blob/d12b12b043a71d8471454f7b4fc84c3181d2bf60/packages/system/dracut/immutable-rootfs/30cos-immutable-rootfs/cos-generator.sh#L29
 {
     echo "[Unit]"


### PR DESCRIPTION
Disable the module creating any services if the inmutability layer is not gonna run as it makes no sense to load kcrypt if we are not mounting our stuff.

Fixes https://github.com/kairos-io/kairos/issues/642