### PR TITLE
[DO NOT MERGE] Trigger udev to populate disk info

### DIFF
--- a/pkg/lib/lock.go
+++ b/pkg/lib/lock.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -59,13 +60,12 @@ func Luksify(label, version string, tpm bool) (string, error) {
 	}
 
 	// Make sure ghw will see all partitions correctly.
-	// Some versions of udevadm don't support --settle (e.g. alpine)
-	// and older versions don't have --type=all. Try the simpler version then.
-	out, err := SH("udevadm trigger --settle -v --type=all || udevadm trigger -v")
+	// older versions don't have --type=all. Try the simpler version then.
+	out, err := SH("udevadm trigger settle --type=all || udevadm trigger")
 	if err != nil {
 		return "", fmt.Errorf("udevadm trigger failed: %w, out: %s", err, out)
 	}
-	SH("sync") //nolint:errcheck
+	syscall.Sync()
 
 	part, b, err := FindPartition(label)
 	if err != nil {


### PR DESCRIPTION
because otherwise, sometimes the encrypted partition doesn't show up as
type: crypto_LUKS but as type: unknown making kcrypt skip it completely

Part of kairos-io/kairos#2511

(an additional seems to be needed in kairos-agent when locking the
partitions to fully fix the issue)

Signed-off-by: Dimitris Karakasilis <dimitris@karakasilis.me>