### PR TITLE
Allow random partitions encryption

### DIFF
--- a/pkg/lib/lock.go
+++ b/pkg/lib/lock.go
@@ -208,9 +208,12 @@ func formatLuks(device, name, mapper, label, pass string, logger types.KairosLog
 	}
 
 	l.Debug().Msg("discards")
-	out, err = SH(fmt.Sprintf("cryptsetup refresh --persistent --allow-discards %s", mapper))
+	// Refresh needs the password as its doing actions on the device directly
+	cmd := exec.Command("cryptsetup", "refresh", "--persistent", "--allow-discards", mapper)
+	cmd.Stdin = strings.NewReader(pass)
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("refresh err: %w, out: %s", err, out)
+		return fmt.Errorf("refresh err: %w, out: %s", err, string(output))
 	}
 
 	l.Debug().Msg("close")

--- a/pkg/lib/unlock.go
+++ b/pkg/lib/unlock.go
@@ -72,8 +72,14 @@ func UnlockAllWithLogger(tpm bool, log types.KairosLogger) error {
 						}
 					} else {
 						p.FilesystemLabel, err = config.GetLabelForUUID(volumeUUID)
+						// This is a not known filesystem label, so we will try to unlock by uuid or by partition label
+						// Notice that we lock by uuid and filesystem label so the label usually wont match between the fs label and partition label
+						// Unless set by the user to be the same one
 						if err != nil {
-							return err
+							if p.FilesystemLabel == "" || p.FilesystemLabel == "unknown" {
+								p.FilesystemLabel = p.Label
+							}
+							logger.Warn().Msg("Not known filesystem label, will try to unlock by uuid or by partition label")
 						}
 						err = UnlockDisk(p)
 						if err != nil {


### PR DESCRIPTION
Instead of directly failing here, we let the unlock go its way and move the partition label to be used as the fs label. 

This doesnt mean it will unlock automatically but if there is an entry in a sealedvolume that covers both the fs label and uuid, it will identify the secret by the uuid.

For example, for a static password:

```
---
apiVersion: v1
kind: Secret
metadata:
  name: SECRET_NAME
  namespace: default
type: Opaque
stringData:
  pass: "awesome-plaintext-passphrase"
---
apiVersion: keyserver.kairos.io/v1alpha1
kind: SealedVolume
metadata:
    name: NAME
    namespace: default
spec:
  TPMHash: "HASH"
  partitions:
    - label: EXTRA_PARTITION1
      uuid: 1843896f-1054-56c4-afef-2030241875ca
      secret:
       name: SECRET_NAME
       path: pass
  quarantined: false
```

This would match the pass to use by the label on the first lock (when searching for an existing password) and then on unlock it would match on UUID for the partition with FS label `EXTRA_PARTITION1`


Or for the automatic password generation it would be as such:

```
---
apiVersion: keyserver.kairos.io/v1alpha1
kind: SealedVolume
metadata:
  name: "NAME"
  namespace: default
spec:
  TPMHash: "HASH"
  partitions:
    - label: EXTRA_PARTITION1
      uuid: 1843896f-1054-56c4-afef-2030241875ca
  quarantined: false
```

All of our partitions UUID are predictable as they are based on the label name so running `uuidgen --namespace @url --sha1 --name "EXTRA_PARTITION1"` generates the UUID `1843896f-1054-56c4-afef-2030241875ca`

This all comes because the FS label is used on the unlocked volume, and when its locked, you cant see that label, only the partition label.

Its possible as well to skip using the UUID if on an extra partition you set the `name` and `label` to the same value, so the locker and unlocker will both use the same reference values, for example:

```
install:
  extra-partitions:
    - name: extra1
      size: 1000
      fs: ext4
      label: extra1
```

This would mean the the locked partition would have a `extra1` partition label, and the unlocked device would have the `extra` filesystem label, so they would both match.

Several options to choose here but they are all achievable.

This has been tested on all the posible scenarios in our tests (remote-auto, remote-static, local) with this kcrypt version and immucore and agent build against it. No other changes done to both agent or immucore other than updating the kcrypt version to point at this commit.

This also brings a small fix for the discards option of luks not being set properly because its asking for the password of the device.